### PR TITLE
Refine case search endpoint and model serialization

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,7 +1,7 @@
 from flask import Flask, abort, request, jsonify
 from flask_cors import CORS
 from http import HTTPStatus
-from db.db_models import Opinion
+from db.db_models import Opinion, DEFAULT_SERIALIZATION_ARGS
 from graph.citation_network import CitationNetwork
 from playhouse.shortcuts import model_to_dict
 from helpers import model_list_to_json
@@ -38,7 +38,7 @@ def upload_pdf():
 def get_case(resource_id: int):
     try:
         opinion = Opinion.get(resource_id=resource_id)
-        return model_to_dict(opinion)
+        return model_to_dict(opinion, **DEFAULT_SERIALIZATION_ARGS)
     except Opinion.DoesNotExist:
         abort(HTTPStatus.NOT_FOUND)
 
@@ -61,7 +61,8 @@ def search():
     if search_query is None or len(search_query) == 0:
         return jsonify([])
     search_results = CaseSearch.search_cases(search_query, max_cases=max_cases)
-    return model_list_to_json(search_results)
+    return model_list_to_json(search_results, extra_attrs=['headline'])
+
 
 
 @app.route('/cases/<int:resource_id>/oyez_brief')

--- a/api.py
+++ b/api.py
@@ -30,7 +30,7 @@ def upload_pdf():
         return "No file provided.", HTTPStatus.UNPROCESSABLE_ENTITY
     pdf_text = PdfEngine(BufferedReader(file)).get_text()
     citations = list(CitationExtractor(pdf_text).get_extracted_citations())
-    return jsonify(citations)
+    return model_list_to_json(citations, extra_attrs=['parentheticals'])
 
 
 # TODO: All of these /cases/ routes can be refactored into their own Flask blueprint

--- a/db/db_helpers.py
+++ b/db/db_helpers.py
@@ -1,0 +1,5 @@
+from peewee import Expression
+
+
+def ts_match(vector, query):
+    return Expression(vector, '@@', query)

--- a/db/db_models.py
+++ b/db/db_models.py
@@ -1,6 +1,5 @@
-from peewee import IntegerField, TextField, ForeignKeyField, FloatField
+from peewee import IntegerField, TextField, ForeignKeyField, FloatField, fn
 from playhouse.postgres_ext import TSVectorField
-from playhouse.sqlite_ext import FTS5Model, SearchField
 from playhouse.signals import Model
 from helpers import connect_to_database
 
@@ -22,6 +21,11 @@ class Cluster(BaseModel):
     year = IntegerField()
     time = IntegerField()
     searchable_case_name = TSVectorField()
+
+    @staticmethod
+    def case_display_name():
+        """Plaintiff v. Defendant, Reporter (Year), written in query syntax."""
+        return fn.CONCAT(Cluster.case_name, fn.coalesce(fn.CONCAT(', ', Cluster.reporter)), ' (', Cluster.year, ')')
 
 
 class Opinion(BaseModel):

--- a/db/db_models.py
+++ b/db/db_models.py
@@ -1,3 +1,4 @@
+from typing import List, Optional
 from peewee import IntegerField, TextField, ForeignKeyField, FloatField, fn
 from playhouse.postgres_ext import TSVectorField
 from playhouse.signals import Model
@@ -34,6 +35,8 @@ class Opinion(BaseModel):
     cluster_uri = TextField()
     html_text = TextField(null=True)
     cluster = ForeignKeyField(Cluster, field='resource_id', backref='opinion')
+
+    parentheticals: Optional[List[str]]
 
 
 class Citation(BaseModel):

--- a/db/db_models.py
+++ b/db/db_models.py
@@ -52,3 +52,8 @@ class ClusterCitation(BaseModel):
     citing_cluster = ForeignKeyField(Cluster, field='resource_id', backref='clustercitation', lazy_load=False)
     cited_cluster = ForeignKeyField(Cluster, field='resource_id', backref='clustercitation', lazy_load=False)
     depth = IntegerField()
+
+
+DEFAULT_SERIALIZATION_ARGS = {
+    "exclude": [Cluster.searchable_case_name, ],
+}

--- a/extraction/citation_extractor.py
+++ b/extraction/citation_extractor.py
@@ -1,5 +1,4 @@
 from typing import Iterable, List, cast
-from playhouse.shortcuts import model_to_dict
 from db.db_models import Opinion, Cluster
 from helpers import format_reporter
 import eyecite
@@ -15,7 +14,7 @@ class CitationExtractor:
     def get_citations(self) -> List[CitationBase]:
         return list(eyecite.get_citations(self.unstructured_text))
 
-    def get_extracted_citations(self) -> List[dict]:
+    def get_extracted_citations(self) -> List[Opinion]:
         cited_resources = eyecite.resolve_citations(self.get_citations())
         reporter_resource_dict = {format_reporter(res.citation.groups['volume'], res.citation.groups['reporter'], res.citation.groups['page']): res
                                   for res in cited_resources}
@@ -27,9 +26,8 @@ class CitationExtractor:
                 if isinstance(citation, CaseCitation) \
                         and citation.metadata.parenthetical is not None:
                     parentheticals.append(citation.metadata.parenthetical)
-            opinion_dict = model_to_dict(opinion)
-            opinion_dict['parentheticals'] = parentheticals
-            extracted_citations.append(opinion_dict)
+            opinion.parentheticals = parentheticals
+            extracted_citations.append(opinion)
         return extracted_citations
 
     def get_opinion_citations(self, cited_resources=None) -> Iterable[Opinion]:

--- a/helpers.py
+++ b/helpers.py
@@ -35,7 +35,9 @@ def connect_to_database():
 
 
 def model_list_to_json(peewee_models: List[Model], **kwargs):
-    return jsonify(list(map(lambda model: model_to_dict(model, **kwargs), peewee_models)))
+    # TODO: Figure out a saner way to avoid these circular import problems
+    from db.db_models import DEFAULT_SERIALIZATION_ARGS  # Has to be here to avoid circular import errors
+    return jsonify(list(map(lambda model: model_to_dict(model, **DEFAULT_SERIALIZATION_ARGS, **kwargs), peewee_models)))
 
 
 def format_reporter(volume, reporter, page):

--- a/helpers.py
+++ b/helpers.py
@@ -34,8 +34,8 @@ def connect_to_database():
     return PostgresqlDatabase(db_name, user=db_username, password=db_password, host=db_host, port=db_port)
 
 
-def model_list_to_json(peewee_models: List[Model]):
-    return jsonify(list(map(model_to_dict, peewee_models)))
+def model_list_to_json(peewee_models: List[Model], **kwargs):
+    return jsonify(list(map(lambda model: model_to_dict(model, **kwargs), peewee_models)))
 
 
 def format_reporter(volume, reporter, page):


### PR DESCRIPTION
This PR does two things:
- Slightly refactors API code to use some shared configuration for serializing peewee models to JSON.
- Modifies the case search query to use `ts_headline` Postgres search's very cool function for highlighting the matching parts of a search.

Together with https://github.com/legal-network/scotus-explorer/pull/4, closes https://github.com/legal-network/scotus-explorer/issues/6.