### PR TITLE
Make postgres triggers/functions/extensions tracked by alembic

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -66,7 +66,7 @@ sqlalchemy.url = driver://user:pass@localhost/TO_BE_OVERRIDDEN
 
 # Logging configuration
 [loggers]
-keys = root,sqlalchemy,alembic
+keys = root,sqlalchemy,alembic,alembic_utils
 
 [handlers]
 keys = console
@@ -88,6 +88,11 @@ qualname = sqlalchemy.engine
 level = INFO
 handlers =
 qualname = alembic
+
+[logger_alembic_utils]
+level = INFO
+handlers =
+qualname = alembic_utils
 
 [handler_console]
 class = StreamHandler

--- a/db/sqlalchemy/alembic/env.py
+++ b/db/sqlalchemy/alembic/env.py
@@ -4,9 +4,11 @@ from sqlalchemy import engine_from_config
 from sqlalchemy import pool
 
 from alembic import context
+from alembic_utils.replaceable_entity import register_entities
 
 from helpers import get_db_url
 from db.sqlalchemy.models import Base as ModelBase
+from db.sqlalchemy.pg_entities import PG_ENTITY_LIST
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -26,6 +28,9 @@ target_metadata = ModelBase.metadata
 # ... etc.
 
 config.set_main_option("sqlalchemy.url", get_db_url())
+
+# Register postgres functions to be tracked by alembic for revisions
+register_entities(PG_ENTITY_LIST)
 
 
 def run_migrations_offline():

--- a/db/sqlalchemy/alembic/versions/bc224e115ea0_initial_migration.py
+++ b/db/sqlalchemy/alembic/versions/bc224e115ea0_initial_migration.py
@@ -7,6 +7,9 @@ Create Date: 2021-12-16 15:56:44.059300
 """
 from alembic import op
 import sqlalchemy as sa
+from alembic_utils.pg_extension import PGExtension
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
 from sqlalchemy.sql import text
 from sqlalchemy.dialects import postgresql
 
@@ -89,19 +92,28 @@ def upgrade():
             to_tsvector('pg_catalog.english', case_name || ' ' || coalesce(reporter, '') || ' ' || year);
         CREATE INDEX searchable_case_name_idx ON cluster USING GIN (searchable_case_name);
         """))
-    conn.execute(text("""
-    CREATE FUNCTION update_searchable_case_name_trigger() RETURNS trigger as $$
-    begin
-        new.searchable_case_name := 
-            to_tsvector('pg_catalog.english', new.case_name || ' ' || coalesce(new.reporter, '') || ' ' || new.year);
-        return new;
-    end
-    $$ LANGUAGE  plpgsql;
 
-    CREATE TRIGGER update_searchable_case_name
-    BEFORE INSERT OR UPDATE ON cluster
-    FOR EACH ROW EXECUTE PROCEDURE update_searchable_case_name_trigger();
-    """))
+    public_pg_trgm = PGExtension(
+        schema="public",
+        signature="pg_trgm"
+    )
+    op.create_entity(public_pg_trgm)
+
+    public_update_searchable_case_name_trigger = PGFunction(
+        schema="public",
+        signature="update_searchable_case_name_trigger()",
+        definition="RETURNS trigger\n      LANGUAGE plpgsql\n      AS $$\n      begin\n          new.searchable_case_name := \n              to_tsvector('pg_catalog.english', new.case_name || ' ' || coalesce(new.reporter, '') || ' ' || new.year);\n          return new;\n      end\n      $$"
+    )
+    op.create_entity(public_update_searchable_case_name_trigger)
+
+    public_cluster_update_searchable_case_name = PGTrigger(
+        schema="public",
+        signature="update_searchable_case_name",
+        on_entity="public.cluster",
+        is_constraint=False,
+        definition='BEFORE INSERT OR UPDATE ON public.cluster\n      FOR EACH ROW EXECUTE PROCEDURE public.update_searchable_case_name_trigger()'
+    )
+    op.create_entity(public_cluster_update_searchable_case_name)
 
 
 def downgrade():
@@ -123,3 +135,23 @@ def downgrade():
     op.drop_index('idx_40711_citation_cited_opinion_id', table_name='citation')
     op.drop_table('citation')
     # ### end Alembic commands ###
+    public_pg_trgm = PGExtension(
+        schema="public",
+        signature="pg_trgm"
+    )
+    op.drop_entity(public_pg_trgm)
+    public_cluster_update_searchable_case_name = PGTrigger(
+        schema="public",
+        signature="update_searchable_case_name",
+        on_entity="public.cluster",
+        is_constraint=False,
+        definition='BEFORE INSERT OR UPDATE ON public.cluster\n      FOR EACH ROW EXECUTE PROCEDURE public.update_searchable_case_name_trigger()'
+    )
+    op.drop_entity(public_cluster_update_searchable_case_name)
+
+    public_update_searchable_case_name_trigger = PGFunction(
+        schema="public",
+        signature="update_searchable_case_name_trigger()",
+        definition="RETURNS trigger\n      LANGUAGE plpgsql\n      AS $$\n      begin\n          new.searchable_case_name := \n              to_tsvector('pg_catalog.english', new.case_name || ' ' || coalesce(new.reporter, '') || ' ' || new.year);\n          return new;\n      end\n      $$"
+    )
+    op.drop_entity(public_update_searchable_case_name_trigger)

--- a/db/sqlalchemy/alembic/versions/bc224e115ea0_initial_migration.py
+++ b/db/sqlalchemy/alembic/versions/bc224e115ea0_initial_migration.py
@@ -86,12 +86,7 @@ def upgrade():
     op.create_index('idx_40750_similarity_opinion_b_id', 'similarity', ['opinion_b_id'], unique=False)
     # ### end Alembic commands ###
 
-    conn = op.get_bind()
-    conn.execute(text("""
-        UPDATE cluster SET searchable_case_name = 
-            to_tsvector('pg_catalog.english', case_name || ' ' || coalesce(reporter, '') || ' ' || year);
-        CREATE INDEX searchable_case_name_idx ON cluster USING GIN (searchable_case_name);
-        """))
+    op.create_index('searchable_case_name_idx', 'cluster', ['searchable_case_name'], unique=False, postgresql_using='gin')
 
     public_pg_trgm = PGExtension(
         schema="public",

--- a/db/sqlalchemy/models.py
+++ b/db/sqlalchemy/models.py
@@ -77,7 +77,7 @@ class Cluster(Base):
     court = Column(Text)
 
     __table_args__ = (
-        Index('searchable_case_name_idx', 'searchable_case_name', unique=False),
+        Index('searchable_case_name_idx', 'searchable_case_name', postgresql_using='gin', unique=False),
     )
 
 

--- a/db/sqlalchemy/pg_entities.py
+++ b/db/sqlalchemy/pg_entities.py
@@ -1,0 +1,38 @@
+from alembic_utils.pg_extension import PGExtension
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
+
+# NOTE: When adding any new entities, remember to add it to the PG_ENTITY_LIST at the bottom of this file.
+
+pg_trgm_extension = PGExtension(
+    schema='public',
+    signature='pg_trgm'
+)
+
+update_searchable_case_name_func = PGFunction(
+    schema='public',
+    signature='update_searchable_case_name_trigger()',
+    definition="""
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $$
+      begin
+          new.searchable_case_name := 
+              to_tsvector('pg_catalog.english', new.case_name || ' ' || coalesce(new.reporter, '') || ' ' || new.year);
+          return new;
+      end
+      $$;
+  """
+)
+
+update_searchable_case_name_trigger = PGTrigger(
+    schema='public',
+    signature='update_searchable_case_name',
+    on_entity='public.cluster',
+    definition="""
+      BEFORE INSERT OR UPDATE ON public.cluster
+      FOR EACH ROW EXECUTE PROCEDURE public.update_searchable_case_name_trigger()
+  """
+)
+
+PG_ENTITY_LIST = [pg_trgm_extension, update_searchable_case_name_func, update_searchable_case_name_trigger]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,5 @@ scikit_learn==1.0.1
 scipy==1.6.3
 sqlalchemy==1.4.28
 alembic==1.7.5
+alembic_utils==0.7.4
 sqlacodegen==2.3.0


### PR DESCRIPTION
This is a minor DB infrastructure change that makes no functionality changes/migrations, so I'll go ahead and just merge this once #33 is merged.

Closes #35.