### PR TITLE
Replace print statements with timestamped logging

### DIFF
--- a/algorithms/case_recommendation.py
+++ b/algorithms/case_recommendation.py
@@ -3,6 +3,7 @@ from math import sqrt, log
 from graph import CitationNetwork
 from algorithms.random_walker import RandomWalker
 from algorithms.helpers import top_n
+from utils.logger import Logger
 
 MAX_NUM_STEPS = 200000
 MAX_WALK_LENGTH = 5
@@ -40,7 +41,7 @@ class CaseRecommendation:
             year_diff = abs(average_case_year - curr_node_metadata.year) if curr_node_metadata.year is not None else 0
             # overall_node_freq_dict[key] = self.relevance_adjusted_score(value, num_neighbors=curr_node_metadata.length)
         top_n_recommendations = top_n(overall_node_freq_dict, num_recommendations)
-        print(top_n_recommendations)
+        Logger.info(top_n_recommendations)
         return top_n_recommendations
 
     def recommendations_for_case(self, opinion_id, num_recommendations,

--- a/algorithms/case_structural_roles.py
+++ b/algorithms/case_structural_roles.py
@@ -3,7 +3,7 @@
 from graph.citation_network import CitationNetwork
 import networkx as nx
 import pickle
-from helpers import get_names_for_id_collection
+from utils import get_names_for_id_collection
 
 from graphrole import RecursiveFeatureExtractor, RoleExtractor
 

--- a/db/peewee/migrations/add_all_citations.py
+++ b/db/peewee/migrations/add_all_citations.py
@@ -2,7 +2,7 @@ import csv
 
 from peewee import chunked
 from db.peewee.models import *
-from ingress.helpers import get_full_path
+from utils.io import get_full_path
 
 
 def drop_existing_citations():

--- a/db/peewee/migrations/add_opinion_text.py
+++ b/db/peewee/migrations/add_opinion_text.py
@@ -2,7 +2,7 @@ import os
 import json
 from playhouse.migrate import *
 from db.peewee.models import *
-from ingress.helpers import get_full_path
+from utils.io import get_full_path
 
 HTML_TEXT_FIELDS = ['html_with_citations', 'html', 'html_lawbox', 'html_columbia', 'html_anon_2020', 'plain_text']
 

--- a/db/peewee/migrations/create_citation_csv.py
+++ b/db/peewee/migrations/create_citation_csv.py
@@ -1,5 +1,5 @@
 from db.peewee.models import *
-from ingress.helpers import get_full_path
+from utils.io import get_full_path
 import csv
 
 CITATION_CSV_PATH = 'data/citation_list.csv'

--- a/db/peewee/migrations/populate_db.py
+++ b/db/peewee/migrations/populate_db.py
@@ -4,7 +4,7 @@ import csv
 import dateutil.parser
 from datetime import timezone
 from db.peewee.models import db, Cluster, Opinion, Citation
-from ingress.helpers import get_full_path
+from utils.io import get_full_path
 from algorithms.helpers import format_reporter
 
 

--- a/experiments/structural_role_analysis.py
+++ b/experiments/structural_role_analysis.py
@@ -1,7 +1,7 @@
 import csv
 from dataclasses import dataclass
 from typing import Dict, List
-from ingress.helpers import get_full_path
+from utils.io import get_full_path
 from db.peewee.models import Citation
 
 STRUCTURAL_ROLE_FILE_PATH = 'data/structural_roles.csv'

--- a/graph/citation_network.py
+++ b/graph/citation_network.py
@@ -7,6 +7,7 @@ from db.sqlalchemy import get_session
 from db.sqlalchemy.models import Citation, Court
 from graph.network_edge_list import NetworkEdgeList
 from utils.io import get_full_path
+from utils.logger import Logger
 
 CITATION_CSV_PATH = 'data/citation_list.csv'
 NETWORK_CACHE_PATH = 'tmp/network_cache.pik'
@@ -24,15 +25,15 @@ class CitationNetwork:
     def get_citation_network(enable_caching=True, scotus_only=False):
         cache_file_path = get_full_path(NETWORK_CACHE_PATH)
         if not enable_caching:
-            print("Loading citation network from database...")
+            Logger.info("Loading citation network from database...")
             return CitationNetwork(scotus_only=scotus_only)
         if os.path.exists(cache_file_path):
-            print("Loading citation network from disk cache...")
+            Logger.info("Loading citation network from disk cache...")
             try:
                 with open(cache_file_path, 'rb') as cache_file:
                     return pickle.load(cache_file)
             except BaseException as err:
-                print("Loading citation network from cache file failed with error:", err)
+                Logger.info("Loading citation network from cache file failed with error:", err)
                 return CitationNetwork(scotus_only=scotus_only)  # Create a new network if fetching from cache fails
         else:  # Otherwise, construct a new network and cache it.
             new_network = CitationNetwork(scotus_only=scotus_only)
@@ -40,7 +41,7 @@ class CitationNetwork:
                 with open(cache_file_path, 'wb') as cache_file:
                     pickle.dump(new_network, cache_file)
             except BaseException as err:
-                print("Saving citation network to cache file failed with error:", err)
+                Logger.info("Saving citation network to cache file failed with error:", err)
             return new_network
 
     @staticmethod

--- a/graph/citation_network.py
+++ b/graph/citation_network.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 from db.sqlalchemy import get_session
 from db.sqlalchemy.models import Citation, Court
 from graph.network_edge_list import NetworkEdgeList
-from ingress.helpers import get_full_path
+from utils.io import get_full_path
 
 CITATION_CSV_PATH = 'data/citation_list.csv'
 NETWORK_CACHE_PATH = 'tmp/network_cache.pik'

--- a/ingress/cl_file_downloader.py
+++ b/ingress/cl_file_downloader.py
@@ -5,7 +5,8 @@ import tarfile
 import threading
 import urllib.request
 
-from ingress.helpers import BASE_CL_DIR, CITATIONS_PATH, CLUSTER_PATH, OPINION_PATH, JURISDICTIONS, get_full_path
+from ingress.helpers import BASE_CL_DIR, CITATIONS_PATH, CLUSTER_PATH, OPINION_PATH, JURISDICTIONS
+from utils.io import get_full_path
 
 BASE_URL = "https://courtlistener.com/api/bulk-data"
 REMOTE_CITATIONS_PATH = "citations/all.csv.gz"

--- a/ingress/cl_file_downloader.py
+++ b/ingress/cl_file_downloader.py
@@ -7,6 +7,7 @@ import urllib.request
 
 from ingress.helpers import BASE_CL_DIR, CITATIONS_PATH, CLUSTER_PATH, OPINION_PATH, JURISDICTIONS
 from utils.io import get_full_path
+from utils.logger import Logger
 
 BASE_URL = "https://courtlistener.com/api/bulk-data"
 REMOTE_CITATIONS_PATH = "citations/all.csv.gz"
@@ -27,23 +28,23 @@ class ClFileDownloader:
         self.get_citation_csv()
 
     def get_data_folder(self, resource_type: str, jurisdiction: str):
-        print(f"Downloading {resource_type} data for jurisdiction {jurisdiction}...")
+        Logger.info(f"Downloading {resource_type} data for jurisdiction {jurisdiction}...")
         tar_file_bytes = urllib.request.urlopen(self.__get_download_url(resource_type, jurisdiction)).read()
-        print(f"Completed {resource_type} data download for jurisdiction {jurisdiction}, extracting...")
+        Logger.info(f"Completed {resource_type} data download for jurisdiction {jurisdiction}, extracting...")
         folder_path = self.__get_folder_path(resource_type, jurisdiction)
         tarfile.open(fileobj=io.BytesIO(tar_file_bytes)).extractall(folder_path)
-        print(f"Completed extraction of {resource_type} data for jurisdiction {jurisdiction}...")
+        Logger.info(f"Completed extraction of {resource_type} data for jurisdiction {jurisdiction}...")
         return folder_path
 
     def get_citation_csv(self):
-        print("Downloading citations CSV...")
+        Logger.info("Downloading citations CSV...")
         tar_file_bytes = urllib.request.urlopen(f"{BASE_URL}/{REMOTE_CITATIONS_PATH}").read()
-        print("Completed citations data download, extracting...")
+        Logger.info("Completed citations data download, extracting...")
         decompressed_file_path = get_full_path(os.path.join(BASE_CL_DIR, CITATIONS_PATH))
         file_contents = gzip.GzipFile(fileobj=io.BytesIO(tar_file_bytes)).read()
         with open(decompressed_file_path, 'wb') as decompressed_file:
             decompressed_file.write(file_contents)
-        print("Completed extraction of citations data...")
+        Logger.info("Completed extraction of citations data...")
 
     def __get_download_url(self, resource_type: str, jurisdiction: str):
         return f"{BASE_URL}/{resource_type}/{jurisdiction}.tar.gz"

--- a/ingress/db_updater.py
+++ b/ingress/db_updater.py
@@ -12,7 +12,8 @@ from sqlalchemy.dialects.postgresql import insert
 from algorithms.helpers import format_reporter
 from db.sqlalchemy import *
 from db.sqlalchemy.models import Cluster, Opinion, Court, Citation
-from ingress.helpers import BASE_CL_DIR, CLUSTER_PATH, OPINION_PATH, CITATIONS_PATH, JURISDICTIONS, get_full_path
+from ingress.helpers import BASE_CL_DIR, CLUSTER_PATH, OPINION_PATH, CITATIONS_PATH, JURISDICTIONS
+from utils.io import get_full_path
 
 DEFAULT_BATCH_SIZE = 10000
 HTML_TEXT_FIELDS = ['html_with_citations', 'html', 'html_lawbox', 'html_columbia', 'html_anon_2020', 'plain_text']

--- a/ingress/helpers.py
+++ b/ingress/helpers.py
@@ -1,7 +1,5 @@
 import os
 
-from dotenv import load_dotenv
-
 from db.sqlalchemy.models import Court
 
 BASE_CL_DIR = os.path.join("data", "cl")
@@ -12,8 +10,3 @@ CITATIONS_PATH = "citations.csv"
 
 JURISDICTIONS = [Court.SCOTUS, Court.CA1, Court.CA2, Court.CA3, Court.CA4, Court.CA5, Court.CA6,
                  Court.CA7, Court.CA8, Court.CA9, Court.CA10, Court.CA11, Court.CADC, Court.CAFC]
-
-
-def get_full_path(relative_project_path):
-    load_dotenv()
-    return os.path.join(os.getenv('PROJECT_PATH'), relative_project_path)

--- a/utils/io.py
+++ b/utils/io.py
@@ -1,0 +1,8 @@
+import os
+
+from dotenv import load_dotenv
+
+
+def get_full_path(relative_project_path):
+    load_dotenv()
+    return os.path.join(os.getenv('PROJECT_PATH'), relative_project_path)

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,0 +1,8 @@
+import logging
+
+logging.basicConfig(
+    format='%(asctime)s %(levelname)-8s %(message)s',
+    level=logging.INFO,
+    datefmt='%Y-%m-%d %H:%M:%S')
+
+Logger = logging.getLogger()


### PR DESCRIPTION
Pretty simple one, just adds a logger with a format that includes a log level and timestamp.

Print statements, where relevant, are changed to `Logger.info`.

Closes #42.